### PR TITLE
Dev: improve scrape, log, .env

### DIFF
--- a/internal/builder/route.go
+++ b/internal/builder/route.go
@@ -64,8 +64,8 @@ func (c *Config) SwaggerRoute() {
 	r.Get("*", swagger.HandlerDefault)
 }
 
-func (c *Config) NotFoundRoute() fiber.Handler {
-	return func(ctx *fiber.Ctx) error {
+func (c *Config) NotFoundRoute() {
+	c.App.Use(func(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusNotFound).JSON(helper.SingleError("route", "NOT_FOUND"))
-	}
+	})
 }

--- a/internal/delivery/messaging/scraped_schedule_consumer.go
+++ b/internal/delivery/messaging/scraped_schedule_consumer.go
@@ -53,6 +53,10 @@ func (c *ScrapedScheduleConsumer) ConsumeScrapeRequests(ctx context.Context) err
 		}
 
 		scraper := scrape.NewScrape(1000)
+		if err := scraper.Initialize(); err != nil {
+			c.log.Errorf("Failed to initialize scraper when processing study program %s: %v", message.Program, err)
+			return err
+		}
 		defer scraper.Cleanup()
 
 		schedules, err := scraper.GetSchedule(ctx, message.FacultyID, message.ProgramID)

--- a/internal/delivery/messaging/user_consumer.go
+++ b/internal/delivery/messaging/user_consumer.go
@@ -49,6 +49,10 @@ func (c *UserConsumer) ConsumeStudyData(ctx context.Context) error {
 		c.log.Infof("Processing study data for NIM: %s", message.NIM)
 
 		scraper := scrape.NewScrape(30)
+		if err := scraper.Initialize(); err != nil {
+			c.log.Errorf("Failed to initialize scraper when processing study data for NIM %s: %v", message.NIM, err)
+			return err
+		}
 		defer scraper.Cleanup()
 
 		// Login with the received credentials

--- a/internal/service/study_plans_service.go
+++ b/internal/service/study_plans_service.go
@@ -26,7 +26,6 @@ type StudyPlansServiceImpl struct {
 	StudyRepository        *repository.StudyPlansRepositoryImpl
 	UserScheduleRepository *repository.UserScheduleRepositoryImpl
 	Producer               *messaging.UserProducer
-	scraper                *scrape.Scrape
 }
 
 func NewStudyService(
@@ -46,7 +45,6 @@ func NewStudyService(
 		StudyRepository:        studyRepository,
 		UserScheduleRepository: userScheduleRepository,
 		Producer:               producer,
-		scraper:                scrape.NewScrape(10),
 	}
 }
 

--- a/pkg/config/logrus.go
+++ b/pkg/config/logrus.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"strings"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -11,9 +9,17 @@ func NewLogrus(v *viper.Viper) *logrus.Logger {
 	log := logrus.New()
 	env := v.GetString("APP_ENV")
 
-	if strings.ToUpper(env) == "PRODUCTION" {
+	if env == "production" {
 		log.SetFormatter(
-			&logrus.JSONFormatter{},
+			&logrus.JSONFormatter{
+				TimestampFormat: "2006-01-02 15:04:05",
+				FieldMap: logrus.FieldMap{
+					logrus.FieldKeyTime:  "@timestamp",
+					logrus.FieldKeyLevel: "@level",
+					logrus.FieldKeyMsg:   "@message",
+					logrus.FieldKeyFunc:  "@caller",
+				},
+			},
 		)
 	}
 

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -14,8 +14,10 @@ func NewViper() *viper.Viper {
 	v.AllowEmptyEnv(false)
 	v.AutomaticEnv()
 
-	if err := v.ReadInConfig(); err != nil {
-		fmt.Println("Error reading config file, will use environment variables: ", err)
+	if v.GetString("APP_ENV") != "production" {
+		if err := v.ReadInConfig(); err != nil {
+			fmt.Println("Error reading config file, will use environment variables: ", err)
+		}
 	}
 
 	return v

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -8,12 +8,20 @@ import (
 )
 
 type Scrape struct {
-	ctx    context.Context
-	cancel context.CancelFunc
+	timeout int
+	ctx     context.Context
+	cancel  context.CancelFunc
 }
 
 // NewScrape creates a new scraper with initialized ChromeDP context
 func NewScrape(timeout int) *Scrape {
+	return &Scrape{
+		timeout: timeout,
+	}
+}
+
+// Initialize sets up the ChromeDP context
+func (s *Scrape) Initialize() error {
 	opts := append(
 		chromedp.DefaultExecAllocatorOptions[:],
 		chromedp.UserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0"),
@@ -29,12 +37,11 @@ func NewScrape(timeout int) *Scrape {
 
 	// Create context with timeout
 	ctx, _ := chromedp.NewContext(allocCtx)
-	ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, time.Duration(s.timeout)*time.Second)
 
-	return &Scrape{
-		ctx:    ctx,
-		cancel: cancel,
-	}
+	s.ctx = ctx
+	s.cancel = cancel
+	return nil
 }
 
 func (s *Scrape) Cleanup() {


### PR DESCRIPTION
This pull request includes several changes to improve the initialization and usage of the `scrape` package, as well as some minor refactoring and cleanup. The most important changes include initializing the scraper in various methods, removing unused scraper fields, and updating the logging configuration.

### Initialization and usage of the scraper:

* [`internal/delivery/messaging/scraped_schedule_consumer.go`](diffhunk://#diff-90338019131cce75d7851e3e08178acaaeab9a5ff5f6e532cb9e9a000139a7b1R56-R59): Added initialization and error handling for the scraper in the `ConsumeScrapeRequests` method.
* [`internal/delivery/messaging/user_consumer.go`](diffhunk://#diff-2c2f52854a41fddd913af710b2d6f1578f27f2abbd278ea5b7a484cdb26579d8R52-R55): Added initialization and error handling for the scraper in the `ConsumeStudyData` method.
* [`internal/service/user_service.go`](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL49): Added initialization and cleanup for the scraper in the `Register` method, and replaced the usage of the old scraper field with the newly initialized scraper. [[1]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL49) [[2]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL75) [[3]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccR89-R95) [[4]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL106-R111)

### Removal of unused scraper fields:

* [`internal/service/study_plans_service.go`](diffhunk://#diff-e8f5d81d4f74d7dcdfd2d72b624b20212ce6dc2e7c1f6ca56b87b6bb7814e32dL29): Removed the unused `scraper` field from the `StudyPlansServiceImpl` struct and its initialization. [[1]](diffhunk://#diff-e8f5d81d4f74d7dcdfd2d72b624b20212ce6dc2e7c1f6ca56b87b6bb7814e32dL29) [[2]](diffhunk://#diff-e8f5d81d4f74d7dcdfd2d72b624b20212ce6dc2e7c1f6ca56b87b6bb7814e32dL49)
* [`internal/service/user_service.go`](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL49): Removed the unused `scraper` field from the `UserServiceImpl` struct and its initialization. [[1]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL49) [[2]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL75)

### Logging configuration updates:

* [`pkg/config/logrus.go`](diffhunk://#diff-85724c317417948adff44c12f422d098c57091f345e2ad9fcc375f0ac5261782L4-L5): Updated the `NewLogrus` function to use a more detailed JSON formatter in production, including timestamp format and field mapping. [[1]](diffhunk://#diff-85724c317417948adff44c12f422d098c57091f345e2ad9fcc375f0ac5261782L4-L5) [[2]](diffhunk://#diff-85724c317417948adff44c12f422d098c57091f345e2ad9fcc375f0ac5261782L14-R22)

### Other changes:

* [`pkg/config/viper.go`](diffhunk://#diff-867db1230ced57e83cf4ccd465e5a70cff73c07c7ab38d639bc3ee7bf65ff0b7R17-R21): Added a condition to only read the config file if the environment is not production.
* [`pkg/scrape/scrape.go`](diffhunk://#diff-0d2cdf37af14b7dc3eecffc958c6d29a95231ac30af1492166444839c16b4d50R11-R24): Added a `timeout` field to the `Scrape` struct, and updated the `NewScrape` and `Initialize` methods to use this field. [[1]](diffhunk://#diff-0d2cdf37af14b7dc3eecffc958c6d29a95231ac30af1492166444839c16b4d50R11-R24) [[2]](diffhunk://#diff-0d2cdf37af14b7dc3eecffc958c6d29a95231ac30af1492166444839c16b4d50L32-R44)
* [`internal/builder/route.go`](diffhunk://#diff-83ca9919b4cc9eff7fb5ad63f54346ba9237db71d3b434363a36dd1a2c010966L67-R70): Simplified the `NotFoundRoute` method to use the `fiber.Ctx` directly.