### PR TITLE
Fix: Add error handling for scraper initialization

### DIFF
--- a/internal/service/schedule_orchestrator_service.go
+++ b/internal/service/schedule_orchestrator_service.go
@@ -42,6 +42,9 @@ func (s *ScheduleOrchestratorServiceImpl) RunScheduleScraping(ctx context.Contex
 
 	// Get study programs
 	scraper := scrape.NewScrape(1000)
+	if err := scraper.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize scraper: %w", err)
+	}
 	defer scraper.Cleanup()
 
 	studyPrograms, err := scraper.GetStudyPrograms(ctx)


### PR DESCRIPTION
This pull request includes a change to the `RunScheduleScraping` function in the `internal/service/schedule_orchestrator_service.go` file. The change ensures that the scraper is properly initialized and handles any initialization errors.

* [`internal/service/schedule_orchestrator_service.go`](diffhunk://#diff-03b353122ae6dc449beddc75eeb1500a370a97fdc518236313c4f37186e18ad7R45-R47): Added initialization of the scraper and error handling to the `RunScheduleScraping` function.