### PR TITLE
Refactor(helper): Improve lecturer name anonymization logic

### DIFF
--- a/pkg/helper/string_helper.go
+++ b/pkg/helper/string_helper.go
@@ -18,51 +18,24 @@ func TrimLecturerName(name string) string {
 		return name
 	}
 
-	// Split by possible lecturer separators
-	lecturers := strings.Split(name, "Oktira")
-	if len(lecturers) == 1 {
-		return trimSingleLecturer(name)
-	}
+	// Split by spaces to handle multiple names
+	names := strings.Split(name, " ")
+	var result []string
 
-	// Handle multiple lecturers case
-	var trimmedNames []string
-	for _, lecturer := range lecturers {
-		trimmedNames = append(trimmedNames, trimSingleLecturer(strings.TrimSpace(lecturer)))
-	}
-	return strings.Join(trimmedNames, " & ")
-}
-
-func trimSingleLecturer(name string) string {
-	// Handle titles and prefixes
-	name = strings.TrimPrefix(name, "Prof. ")
-	name = strings.TrimPrefix(name, "Dr., ")
-	name = strings.TrimPrefix(name, "Drs. ")
-	name = strings.TrimPrefix(name, "Hj. ")
-	name = strings.TrimPrefix(name, "H. ")
-
-	// Get first 3 chars of actual name
-	first := name[:3]
-
-	// Find first comma, period or space
-	var endIndex int
-	for i := 3; i < len(name); i++ {
-		if name[i] == ',' || name[i] == ' ' || name[i] == '.' {
-			endIndex = i
-			break
+	for _, n := range names {
+		if len(n) <= 3 {
+			result = append(result, n)
+			continue
 		}
+
+		// Take first 3 chars and add asterisks
+		first := n[:3]
+		padding := ""
+		for i := 0; i < len(n)-3; i++ {
+			padding += "*"
+		}
+		result = append(result, first+padding)
 	}
 
-	// If no separator found, use full length
-	if endIndex == 0 {
-		endIndex = len(name)
-	}
-
-	// Create asterisk padding
-	padding := ""
-	for i := 0; i < endIndex-3; i++ {
-		padding += "*"
-	}
-
-	// Combine first + padding + rest of string
-	return first + padding + name[endIndex:]
+	return strings.Join(result, " ")
 }


### PR DESCRIPTION
This pull request includes a significant change to the `TrimLecturerName` function in the `pkg/helper/string_helper.go` file. The function has been simplified to handle lecturer names by splitting them based on spaces and masking parts of each name with asterisks.

Key changes to `TrimLecturerName` function:

* Removed the handling of multiple lecturers separated by "Oktira" and the `trimSingleLecturer` helper function.
* Simplified the logic by splitting the name based on spaces and masking each part of the name with asterisks after the first three characters.