### PR TITLE
Fix(schedules): add field credits on response

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -161,6 +161,142 @@ const docTemplate = `{
                 }
             }
         },
+        "/auth/reset": {
+            "post": {
+                "description": "Reset password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Reset Password",
+                "parameters": [
+                    {
+                        "description": "Reset Password Request",
+                        "name": "reset_password",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.UserResetPassword"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/reset/request": {
+            "post": {
+                "description": "Reset password request",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Reset Password Request",
+                "parameters": [
+                    {
+                        "description": "Reset Password Request",
+                        "name": "reset_password_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.UserResetPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/verify/{token}": {
+            "get": {
+                "description": "Verify email",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Verify Email",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/schedules": {
             "get": {
                 "description": "Get schedules",
@@ -611,6 +747,32 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_savioruz_smrv2-api_internal_dao_model.UserResetPassword": {
+            "type": "object",
+            "required": [
+                "password",
+                "token"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_savioruz_smrv2-api_internal_dao_model.UserResetPasswordRequest": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_savioruz_smrv2-api_internal_dao_model.UserSchedulesResponse": {
             "type": "object",
             "properties": {
@@ -622,6 +784,9 @@ const docTemplate = `{
                 },
                 "course_name": {
                     "type": "string"
+                },
+                "credits": {
+                    "type": "integer"
                 },
                 "day": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -154,6 +154,142 @@
                 }
             }
         },
+        "/auth/reset": {
+            "post": {
+                "description": "Reset password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Reset Password",
+                "parameters": [
+                    {
+                        "description": "Reset Password Request",
+                        "name": "reset_password",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.UserResetPassword"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/reset/request": {
+            "post": {
+                "description": "Reset password request",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Reset Password Request",
+                "parameters": [
+                    {
+                        "description": "Reset Password Request",
+                        "name": "reset_password_request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.UserResetPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/verify/{token}": {
+            "get": {
+                "description": "Verify email",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Verify Email",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/schedules": {
             "get": {
                 "description": "Get schedules",
@@ -604,6 +740,32 @@
                 }
             }
         },
+        "github_com_savioruz_smrv2-api_internal_dao_model.UserResetPassword": {
+            "type": "object",
+            "required": [
+                "password",
+                "token"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_savioruz_smrv2-api_internal_dao_model.UserResetPasswordRequest": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_savioruz_smrv2-api_internal_dao_model.UserSchedulesResponse": {
             "type": "object",
             "properties": {
@@ -615,6 +777,9 @@
                 },
                 "course_name": {
                     "type": "string"
+                },
+                "credits": {
+                    "type": "integer"
                 },
                 "day": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -67,6 +67,23 @@ definitions:
       refresh_token:
         type: string
     type: object
+  github_com_savioruz_smrv2-api_internal_dao_model.UserResetPassword:
+    properties:
+      password:
+        type: string
+      token:
+        type: string
+    required:
+    - password
+    - token
+    type: object
+  github_com_savioruz_smrv2-api_internal_dao_model.UserResetPasswordRequest:
+    properties:
+      email:
+        type: string
+    required:
+    - email
+    type: object
   github_com_savioruz_smrv2-api_internal_dao_model.UserSchedulesResponse:
     properties:
       class_code:
@@ -75,6 +92,8 @@ definitions:
         type: string
       course_name:
         type: string
+      credits:
+        type: integer
       day:
         type: string
       end_time:
@@ -240,6 +259,95 @@ paths:
           schema:
             $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse'
       summary: Register
+      tags:
+      - Auth
+  /auth/reset:
+    post:
+      consumes:
+      - application/json
+      description: Reset password
+      parameters:
+      - description: Reset Password Request
+        in: body
+        name: reset_password
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.UserResetPassword'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse'
+      summary: Reset Password
+      tags:
+      - Auth
+  /auth/reset/request:
+    post:
+      consumes:
+      - application/json
+      description: Reset password request
+      parameters:
+      - description: Reset Password Request
+        in: body
+        name: reset_password_request
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.UserResetPasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse'
+      summary: Reset Password Request
+      tags:
+      - Auth
+  /auth/verify/{token}:
+    get:
+      consumes:
+      - application/json
+      description: Verify email
+      parameters:
+      - description: Token
+        in: path
+        name: token
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.Response-string'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_savioruz_smrv2-api_internal_dao_model.ErrorResponse'
+      summary: Verify Email
       tags:
       - Auth
   /schedules:

--- a/internal/dao/model/user_schedule_model.go
+++ b/internal/dao/model/user_schedule_model.go
@@ -18,6 +18,7 @@ type UserSchedulesResponse struct {
 	Lecturer     string `json:"lecturer,omitempty"`
 	StudyProgram string `json:"study_program"`
 	Semester     string `json:"semester"`
+	Credits      int32  `json:"credits"`
 }
 
 type UserSchedulesSyncRequest struct {

--- a/internal/repository/user_schedule_repository.go
+++ b/internal/repository/user_schedule_repository.go
@@ -51,7 +51,8 @@ func (r *UserScheduleRepositoryImpl) GetSchedules(ctx context.Context, userID st
 			ss.room_number,
 			ss.lecturer_name AS lecturer,
 			ss.study_program,
-			ss.semester
+			ss.semester,
+			ss.credits
 		FROM user_schedules us
 		JOIN study_plans sp ON us.study_plan_id = sp.id
 		JOIN scraped_schedules ss ON us.course_code = ss.course_code 


### PR DESCRIPTION
This pull request includes several changes to the API documentation and internal data models related to authentication and user schedules. The most important changes include adding new endpoints for password reset and email verification, updating the user schedule model to include credits, and corresponding updates to the Swagger documentation.

### API Documentation Updates:

* Added new endpoints for password reset (`/auth/reset` and `/auth/reset/request`) and email verification (`/auth/verify/{token}`) in `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml`. These endpoints include descriptions, request parameters, and response schemas. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R164-R299) [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R157-R292) [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R264-R352)

### Data Model Updates:

* Introduced new data models `UserResetPassword` and `UserResetPasswordRequest` in `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml` to support the new password reset endpoints. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R750-R775) [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R743-R768) [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R70-R86)

### User Schedule Updates:

* Updated the `UserSchedulesResponse` model to include a `credits` field in `docs/docs.go`, `docs/swagger.json`, `docs/swagger.yaml`, and `internal/dao/model/user_schedule_model.go`. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R788-R790) [[2]](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524R781-R783) [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R95-R96) [[4]](diffhunk://#diff-8b1740cd3a5087a0944df469118fea9a49332ade3a463dbcb62415f10fefc9f5R21)
* Modified the `GetSchedules` query in `internal/repository/user_schedule_repository.go` to retrieve the `credits` field.