### PR TITLE
Fix(schedules): credits convert into int32

### DIFF
--- a/internal/service/scraped_schedule_service.go
+++ b/internal/service/scraped_schedule_service.go
@@ -200,6 +200,7 @@ func (s *ScrapedScheduleServiceImpl) GetSchedules(ctx context.Context, request *
 			Lecturer:     schedules[i].LecturerName,
 			StudyProgram: schedules[i].StudyProgram,
 			Semester:     schedules[i].Semester,
+			Credits:      int32(schedules[i].Credits),
 		}
 	}
 


### PR DESCRIPTION
This pull request includes a small change to the `internal/service/scraped_schedule_service.go` file. The change involves adding the `Credits` field to the `GetSchedules` method to include the number of credits for each schedule.

* [`internal/service/scraped_schedule_service.go`](diffhunk://#diff-2ab06e9991939e1700e071cff7f0405451484b7c27a138277cd89a5da0e7c201R203): Added the `Credits` field to the `GetSchedules` method to include the number of credits for each schedule.