### PR TITLE
Feat(auth): Enhance user login validation and domain restrictions

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -833,7 +833,8 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 6
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -826,7 +826,8 @@
                     "type": "string"
                 },
                 "password": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 6
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -121,6 +121,7 @@ definitions:
       email:
         type: string
       password:
+        minLength: 6
         type: string
     required:
     - email

--- a/internal/dao/model/user_model.go
+++ b/internal/dao/model/user_model.go
@@ -14,7 +14,7 @@ type UsersRegisterRequest struct {
 
 type UsersLoginRequest struct {
 	Email    string `json:"email" validate:"required,email"`
-	Password string `json:"password" validate:"required"`
+	Password string `json:"password" validate:"required,min=6"`
 }
 
 type UsersRegisterResponse struct {


### PR DESCRIPTION
This pull request includes several important changes to improve the validation and error handling in the user authentication process. The changes primarily focus on adding password length validation and refining error messages.

### Validation improvements:

* [`docs/docs.go`](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L836-R837): Added a minimum length of 6 characters for the `password` field in the documentation template.
* [`docs/swagger.json`](diffhunk://#diff-13ab876dd98ef9f0152cbb22b6afabced9ea3de017488018c58c40d015b0a524L829-R830): Added a minimum length of 6 characters for the `password` field in the Swagger JSON file.
* [`docs/swagger.yaml`](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R124): Added a minimum length of 6 characters for the `password` field in the Swagger YAML file.
* [`internal/dao/model/user_model.go`](diffhunk://#diff-723b1d63fae617f5988846295ed08a8f7e58770a6d9b0dc058e98ffee1fb77dfL17-R17): Updated the `UsersLoginRequest` struct to include a minimum length validation of 6 characters for the `password` field.

### Error handling refinements:

* [`internal/service/user_service.go`](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccR194-R204): Added a domain validation for the email field to ensure it contains `@webmail.uad.ac.id`, and refined error messages for invalid credentials and user not found scenarios. [[1]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccR194-R204) [[2]](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL211-R215)