### PR TITLE
Uses headless-shell for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,33 @@
-# Stage 1: Build the Go application
 FROM golang:1.23-bullseye AS builder
 LABEL maintainer="savioruz <jakueenak@gmail.com>"
 
-# Move to working directory (/build).
 WORKDIR /build
 
-# Copy and download dependency using go mod.
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Copy the code into the container.
 COPY . .
 
-# Set necessary environment variables needed for our image and build the API server.
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go build -ldflags="-s -w" -o smrv2-api ./cmd/app/main.go
 
-# Stage 2: Setup the runtime environment
-FROM debian:bullseye-slim
+FROM chromedp/headless-shell:latest
 
-# Avoid prompts from apt
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install necessary runtime dependencies, including Chromium
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    chromium \
-    chromium-driver \
-    fonts-freefont-ttf \
-    libasound2 \
-    libx11-6 \
-    libxcomposite1 \
-    libxcursor1 \
-    libxdamage1 \
-    libxext6 \
-    libxi6 \
-    libxtst6 \
-    libxrandr2 \
-    libxss1 \
-    libglib2.0-0 \
-    libnss3 \
-    libcups2 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libpangocairo-1.0-0 \
-    libgtk-3-0 \
-    wget \
-    xvfb \
+    ca-certificates dumb-init \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
 
-# Update the CA certificates
-RUN update-ca-certificates
+WORKDIR /app
 
-# Copy binary and config files from /build to root folder of scratch container.
-COPY --from=builder ["/build/smrv2-api", "/"]
+COPY --from=builder /build/smrv2-api /app/
+COPY .env /app/
 
-# Set up environment variables for Chromium
-ENV CHROME_BIN=/usr/bin/chromium \
-    CHROME_PATH=/usr/lib/chromium/ \
-    DISPLAY=:99
+RUN chmod +x /app/smrv2-api
 
-# Create a symlink for google-chrome (if needed)
-RUN ln -s /usr/bin/chromium /usr/bin/google-chrome
+EXPOSE 3000
 
-# Add a script to start Xvfb before running the main application
-RUN echo '#!/bin/bash\nXvfb :99 -ac &\nexec "$@"' > /entrypoint.sh \
-    && chmod +x /entrypoint.sh
+ENTRYPOINT ["dumb-init", "--"]
 
-# Use the entrypoint script
-ENTRYPOINT ["/entrypoint.sh"]
-
-# Command to run when starting the container.
-CMD ["/smrv2-api"]
+CMD ["./smrv2-api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY --from=builder /build/smrv2-api /app/
-COPY .env /app/
 
 RUN chmod +x /app/smrv2-api
 

--- a/Dockerfile.chrome
+++ b/Dockerfile.chrome
@@ -1,0 +1,75 @@
+# Stage 1: Build the Go application
+FROM golang:1.23-bullseye AS builder
+LABEL maintainer="savioruz <jakueenak@gmail.com>"
+
+# Move to working directory (/build).
+WORKDIR /build
+
+# Copy and download dependency using go mod.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the code into the container.
+COPY . .
+
+# Set necessary environment variables needed for our image and build the API server.
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+RUN go build -ldflags="-s -w" -o smrv2-api ./cmd/app/main.go
+
+# Stage 2: Setup the runtime environment
+FROM debian:bullseye-slim
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install necessary runtime dependencies, including Chromium
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    chromium \
+    chromium-driver \
+    fonts-freefont-ttf \
+    libasound2 \
+    libx11-6 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxi6 \
+    libxtst6 \
+    libxrandr2 \
+    libxss1 \
+    libglib2.0-0 \
+    libnss3 \
+    libcups2 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libpangocairo-1.0-0 \
+    libgtk-3-0 \
+    wget \
+    xvfb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Update the CA certificates
+RUN update-ca-certificates
+
+# Copy binary and config files from /build to root folder of scratch container.
+COPY --from=builder ["/build/smrv2-api", "/"]
+
+# Set up environment variables for Chromium
+ENV CHROME_BIN=/usr/bin/chromium \
+    CHROME_PATH=/usr/lib/chromium/ \
+    DISPLAY=:99
+
+# Create a symlink for google-chrome (if needed)
+RUN ln -s /usr/bin/chromium /usr/bin/google-chrome
+
+# Add a script to start Xvfb before running the main application
+RUN echo '#!/bin/bash\nXvfb :99 -ac &\nexec "$@"' > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+
+# Use the entrypoint script
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Command to run when starting the container.
+CMD ["/smrv2-api"]

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -24,7 +24,6 @@ func NewScrape(timeout int) *Scrape {
 func (s *Scrape) Initialize() error {
 	opts := append(
 		chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.UserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0"),
 		chromedp.Flag("headless", true),
 		chromedp.Flag("disable-gpu", true),
 		chromedp.Flag("no-sandbox", true),


### PR DESCRIPTION
This pull request includes significant changes to the Docker setup and a minor update to the `scrape.go` file. The Docker setup has been split into two separate Dockerfiles, with one focusing on using the `chromedp/headless-shell` image and the other maintaining the previous setup with Chromium. Additionally, an unnecessary user agent flag has been removed from the `scrape.go` file.

Changes to Docker setup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R32): Switched to using the `chromedp/headless-shell` image for the runtime environment, removed installation of Chromium and related dependencies, and simplified the entrypoint and command setup.
* [`Dockerfile.chrome`](diffhunk://#diff-7ddf59f6f3cb555f19efe693299fdb8c20accf2d84ee855eb6b126fbf29b68b6R1-R75): Added a new Dockerfile that retains the previous setup with Chromium and related dependencies, including the entrypoint script to start Xvfb.

Code update:

* [`pkg/scrape/scrape.go`](diffhunk://#diff-0d2cdf37af14b7dc3eecffc958c6d29a95231ac30af1492166444839c16b4d50L27): Removed the unnecessary `chromedp.UserAgent` option from the `Initialize` method in the `Scrape` struct.