### PR TITLE
Refactor(scraping): Remove scraper initialization from user registration

### DIFF
--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/savioruz/smrv2-api/pkg/helper"
 	"github.com/savioruz/smrv2-api/pkg/jwt"
 	"github.com/savioruz/smrv2-api/pkg/mail"
-	"github.com/savioruz/smrv2-api/pkg/scrape"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
@@ -87,13 +86,6 @@ func (s *UserServiceImpl) Register(ctx context.Context, request *model.UsersRegi
 
 	tx := s.DB.WithContext(ctx).Begin()
 	defer tx.Rollback()
-
-	// Initialize scraperNewScrape(30)
-	scraper := scrape.NewScrape(30)
-	if err := scraper.Initialize(); err != nil {
-		return nil, helper.ServerError(s.Log, "Failed to initialize scraper")
-	}
-	defer scraper.Cleanup()
 
 	// Check if user exists
 	user, err := s.UserRepository.GetByEmail(tx, request.Email)

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -30,7 +30,9 @@ func (s *Scrape) Initialize() error {
 		chromedp.Flag("disable-dev-shm-usage", true),
 		chromedp.Flag("disable-setuid-sandbox", true),
 		chromedp.Flag("remote-debugging-port", "9222"),
-		chromedp.Flag("remote-debugging-address", "127.0.0.1"),
+		chromedp.Flag("remote-debugging-address", "0.0.0.0"),
+		chromedp.Flag("disable-crash-reporter", true),
+		chromedp.Flag("disable-notifications", true),
 		chromedp.Flag("disable-extensions", true),
 		chromedp.Flag("disable-sync", true),
 		chromedp.Flag("disable-background-networking", true),
@@ -39,7 +41,6 @@ func (s *Scrape) Initialize() error {
 		chromedp.Flag("blink-settings", "imagesEnabled=false"),
 		chromedp.Flag("memory-pressure-off", true),
 		chromedp.Flag("disable-software-rasterizer", true),
-		chromedp.WindowSize(800, 600),
 	)
 
 	// Create allocator context
@@ -60,12 +61,16 @@ func (s *Scrape) Initialize() error {
 	s.ctx = ctx
 	s.cancel = cancel
 
-	// Ensure browser is started
-	if err := chromedp.Run(ctx); err != nil {
-		return err
+	var err error
+	for i := 0; i < 3; i++ {
+		err = chromedp.Run(ctx)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(time.Second * 2)
 	}
 
-	return nil
+	return err
 }
 
 func (s *Scrape) Cleanup() {


### PR DESCRIPTION
This pull request includes several changes to the `UserService` and `Scrape` functionalities. The main focus is on removing the scraper initialization from the user registration process and improving the scraper's initialization logic.

### User Service Changes:
* Removed the import of the `scrape` package from `internal/service/user_service.go`.
* Removed the scraper initialization code from the `Register` method in `internal/service/user_service.go`.

### Scrape Service Changes:
* Updated the `Initialize` method in `pkg/scrape/scrape.go` to modify the Chrome debugging address and add flags to disable crash reporter and notifications.
* Removed the window size setting from the `Initialize` method in `pkg/scrape/scrape.go`.
* Modified the `Initialize` method to retry starting the browser up to three times before failing.