### PR TITLE
Refactor(scraping): Simplify chromedp browser configuration flags

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -24,14 +24,11 @@ func NewScrape(timeout int) *Scrape {
 func (s *Scrape) Initialize() error {
 	opts := append(
 		chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.Flag("headless", true),
-		chromedp.Flag("disable-gpu", true),
-		chromedp.Flag("no-sandbox", true),
+		chromedp.DisableGPU,
+		chromedp.Headless,
+		chromedp.NoSandbox,
 		chromedp.Flag("disable-dev-shm-usage", true),
 		chromedp.Flag("disable-setuid-sandbox", true),
-		chromedp.Flag("remote-debugging-port", "9222"),
-		chromedp.Flag("remote-debugging-address", "0.0.0.0"),
-		chromedp.Flag("disable-crash-reporter", true),
 		chromedp.Flag("disable-notifications", true),
 		chromedp.Flag("disable-extensions", true),
 		chromedp.Flag("disable-sync", true),
@@ -41,6 +38,7 @@ func (s *Scrape) Initialize() error {
 		chromedp.Flag("blink-settings", "imagesEnabled=false"),
 		chromedp.Flag("memory-pressure-off", true),
 		chromedp.Flag("disable-software-rasterizer", true),
+		chromedp.Flag("window-size", "800,600"),
 	)
 
 	// Create allocator context


### PR DESCRIPTION
This pull request includes changes to the `pkg/scrape/scrape.go` file to improve the initialization process of the `Scrape` struct by modifying the ChromeDP flags used.

Improvements to ChromeDP flags:

* [`pkg/scrape/scrape.go`](diffhunk://#diff-0d2cdf37af14b7dc3eecffc958c6d29a95231ac30af1492166444839c16b4d50L27-L34): Replaced explicit ChromeDP flags with predefined constants for `DisableGPU`, `Headless`, and `NoSandbox` to simplify the code.
* [`pkg/scrape/scrape.go`](diffhunk://#diff-0d2cdf37af14b7dc3eecffc958c6d29a95231ac30af1492166444839c16b4d50R41): Added a new ChromeDP flag for setting the window size to `800,600` to ensure a consistent window size during scraping.