### PR TITLE
Refactor user fix password reset service

### DIFF
--- a/internal/delivery/http/users_handler.go
+++ b/internal/delivery/http/users_handler.go
@@ -163,7 +163,7 @@ func (h *UserHandlerImpl) VerifyEmail(ctx *fiber.Ctx) error {
 		return ctx.Status(status).JSON(errResp)
 	}
 
-	link := fmt.Sprintf("https://simeru.vercel.app/auth/login?ref=https%%3A%%2F%%2Fsimeru-scraper.koyeb.app&id=%s", request.Token)
+	link := fmt.Sprintf("https://simeru.vercel.app/auth/login?ref=https%%3A%%2F%%2Fsmrv2.svrz.xyz&id=%s", request.Token)
 	return ctx.Redirect(link, fiber.StatusTemporaryRedirect)
 }
 

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -371,7 +371,7 @@ func (s *UserServiceImpl) RequestResetPassword(ctx context.Context, request *mod
 	var replaceEmail = struct {
 		Link string
 	}{
-		Link: fmt.Sprintf("https://simeru.vercel.app/auth/reset?ref=https%%3A%%2F%%2Fsimeru-scraper.koyeb.app&id=%s", resetPasswordToken),
+		Link: fmt.Sprintf("https://simeru.vercel.app/auth/reset?ref=https%%3A%%2F%%2Fsmrv2.svrz.xyz&id=%s", resetPasswordToken),
 	}
 
 	tmpl, err := template.ParseFS(templateFS, "template/verify_email.html")

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -314,7 +314,13 @@ func (s *UserServiceImpl) ResetPassword(ctx context.Context, request *model.User
 		return nil, helper.ServerError(s.Log, "Failed to get user")
 	}
 
-	user.Password = request.Password
+	password, err := helper.EncryptPassword(s.Viper, request.Password)
+	if err != nil {
+		return nil, helper.ServerError(s.Log, "Failed to encrypt password")
+	}
+
+	user.Password = password
+	user.ResetPasswordToken = ""
 	if err := s.UserRepository.Update(tx, user); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, helper.SingleError("user", "NOT_FOUND")


### PR DESCRIPTION
This pull request includes updates to the user authentication flow, specifically addressing email verification and password reset functionalities. The most important changes include updating URLs for email verification and password reset, and adding password encryption during the reset process.

Updates to URLs:

* [`internal/delivery/http/users_handler.go`](diffhunk://#diff-11530217f730ac8ec91cdeff9aa1f05777d90d7e74db1b37269e7cb6cba85dd4L166-R166): Updated the URL in the email verification link to point to the new domain `smrv2.svrz.xyz`.
* [`internal/service/user_service.go`](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL368-R374): Updated the URL in the password reset link to point to the new domain `smrv2.svrz.xyz`.

Password encryption:

* [`internal/service/user_service.go`](diffhunk://#diff-e556d856143b6c60b0cb8476cb448f994fb9dc04491adce9b84bfd417ef5f6ccL317-R323): Added password encryption during the password reset process and cleared the `ResetPasswordToken` after successful password reset.