### PR TITLE
Fix(cors): Update allowed origins for frontend deployment

### DIFF
--- a/internal/delivery/http/middleware/cors_middleware.go
+++ b/internal/delivery/http/middleware/cors_middleware.go
@@ -7,7 +7,7 @@ import (
 
 func CorsMiddleware(a *fiber.App) {
 	a.Use(cors.New(cors.Config{
-		AllowOrigins: "*",
+		AllowOrigins: "https://simeru.vercel.app, https://*.svrz.xyz",
 		AllowHeaders: "Origin, Content-Type, Accept",
 		AllowMethods: "GET,POST,OPTIONS",
 	}))


### PR DESCRIPTION
This pull request includes an important change to the `internal/delivery/http/middleware/cors_middleware.go` file. The change updates the CORS configuration to restrict allowed origins, enhancing security.

* [`internal/delivery/http/middleware/cors_middleware.go`](diffhunk://#diff-cfe3f1bfe2a6c2e7ceb820fa53bd42f06278a8d240484baa65505690bd9b86d3L10-R10): Updated `AllowOrigins` to restrict access to specific domains, improving security by only allowing requests from `https://simeru.vercel.app` and `https://*.svrz.xyz`.